### PR TITLE
Fix tagline punctuation

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -55,7 +55,7 @@ function App() {
             <div className="feature-card">
               <span className="icon">⏰</span>
               <h4>Timely Reminders</h4>
-              <p>Never miss a dose get notified right on time.</p>
+              <p>Never miss a dose, get notified right on time.</p>
             </div>
             <div className="feature-card">
               <span className="icon">📈</span>


### PR DESCRIPTION
## Summary
- update reminders tagline punctuation in the landing page

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68409248cdf883238c4e5a5fcd660dc9