### PR TITLE
Fix Firebase configuration export

### DIFF
--- a/src/database/firebaseResources.js
+++ b/src/database/firebaseResources.js
@@ -5,7 +5,8 @@ const firebaseConfig = {
   apiKey: "AIzaSyAvEh61Dh1HJM5KiEE0--olPeMX7xflnb4",
   authDomain: "tecuido-ea37e.firebaseapp.com",
   projectId: "tecuido-ea37e",
-  storageBucket: "tecuido-ea37e.firebasestorage.app",
+  // Correct host for Firebase Storage
+  storageBucket: "tecuido-ea37e.appspot.com",
   messagingSenderId: "611774216477",
   appId: "1:611774216477:web:0c4ab188a332629d1bc9f4",
   measurementId: "G-CGBT5BR7MM"
@@ -15,7 +16,15 @@ const app = initializeApp(firebaseConfig);
 const auth = getAuth(app);
 const provider = new GoogleAuthProvider();
 
+// Configuration object for react-firebaseui
+const uiConfig = {
+  signInFlow: "popup",
+  signInOptions: [GoogleAuthProvider.PROVIDER_ID],
+  callbacks: {
+    signInSuccessWithAuthResult: () => false,
+  },
+};
+
 const signIn = () => signInWithPopup(auth, provider);
 const logout = () => signOut(auth);
-
-export { auth, signIn, logout };
+export { auth, signIn, logout, uiConfig };


### PR DESCRIPTION
## Summary
- correct Firebase storage bucket name
- add missing `uiConfig` for Firebase UI sign-in

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684090e7826c8323bdb36f01bb107602