### PR TITLE
Add responsive dashboard layout

### DIFF
--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -1,12 +1,47 @@
-import Sidebar from '../components/Sidebar';
+import { Link, Outlet } from 'react-router-dom';
+import { useState } from 'react';
 
 export default function Dashboard() {
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+
+  const toggleSidebar = () => setSidebarOpen(!sidebarOpen);
+
   return (
-    <div className="flex">
-      <Sidebar />
-      <div className="flex-1 p-6">
-        <h1 className="text-2xl font-bold">📋 Dashboard</h1>
+    <div className="min-h-screen md:flex">
+      {/* Mobile top bar */}
+      <div className="md:hidden flex items-center bg-gray-900 text-white p-4">
+        <button
+          onClick={toggleSidebar}
+          aria-label="Toggle navigation"
+          className="mr-2"
+        >
+          ☰
+        </button>
+        <span className="text-lg font-bold">TeCuido</span>
       </div>
+
+      {/* Sidebar */}
+      <aside
+        className={`bg-gray-900 text-white w-64 space-y-6 p-6 md:sticky md:top-0 md:h-screen ${
+          sidebarOpen ? 'block' : 'hidden'
+        } md:block`}
+      >
+        <nav className="flex flex-col gap-3">
+          <Link to="/medications" className="hover:underline">
+            Medications
+          </Link>
+          <Link to="/appointments" className="hover:underline">
+            Appointments
+          </Link>
+          <Link to="/chatbot" className="hover:underline">
+            Chatbot
+          </Link>
+        </nav>
+      </aside>
+
+      <main className="flex-1 p-6">
+        <Outlet />
+      </main>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- implement `Dashboard.jsx` as a layout component with a sticky sidebar
- use `<Outlet />` for nested routing and mobile sidebar toggle

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684234d3fdf08323aa2ef52a4f3271a3