### PR TITLE
Add basic routing with nested dashboard

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,68 +1,21 @@
-import { useEffect, useState } from "react";
-import { auth, signIn, logout } from "./database/firebaseResources";
-import { onAuthStateChanged } from "firebase/auth";
-import "./App.css";
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import Landing from './pages/Landing.jsx';
+import Dashboard from './pages/Dashboard.jsx';
+import Medications from './pages/Medications.jsx';
+import Appointments from './pages/Appointments.jsx';
+import Chatbot from './pages/Chatbot.jsx';
 
-function App() {
-  const [user, setUser] = useState(null);
-
-  useEffect(() => {
-    const unsubscribe = onAuthStateChanged(auth, (user) => {
-      setUser(user);
-    });
-
-    return () => unsubscribe();
-  }, []);
-
+export default function App() {
   return (
-    <div className="app-container">
-      <div className="card-wrapper">
-
-        <section className="hero">
-          <h1>
-            Welcome to <span className="highlight">TeCuido</span>
-          </h1>
-          <p className="tagline">Never miss a dose</p>
-  
-          {user ? (
-            <>
-              <h2>Hello, {user.displayName}</h2>
-              <img src={user.photoURL} alt="Profile" className="profile-img" />
-              <button onClick={logout} className="btn">Sign Out</button>
-            </>
-          ) : (
-            <button onClick={signIn} className="btn cta-btn">Get Started</button>
-          )}
-  
-          <p className="description">
-            This is your personal medication reminder app.
-          </p>
-        </section>
-  
-        <section className="features">
-          <h3>How it works</h3>
-          <div className="features-container">
-            <div className="feature-card">
-              <span className="icon">📋</span>
-              <h4>Add Medications</h4>
-              <p>Keep track of your daily prescriptions with ease.</p>
-            </div>
-            <div className="feature-card">
-              <span className="icon">⏰</span>
-              <h4>Timely Reminders</h4>
-              <p>Never miss a dose, get notified right on time.</p>
-            </div>
-            <div className="feature-card">
-              <span className="icon">📈</span>
-              <h4>Stay On Track</h4>
-              <p>Monitor your routine and build consistency.</p>
-            </div>
-          </div>
-        </section>
-  
-      </div>
-    </div>
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<Landing />} />
+        <Route path="/dashboard" element={<Dashboard />}>
+          <Route path="medications" element={<Medications />} />
+          <Route path="appointments" element={<Appointments />} />
+          <Route path="chatbot" element={<Chatbot />} />
+        </Route>
+      </Routes>
+    </BrowserRouter>
   );
 }
-
-export default App;

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -6,9 +6,9 @@ export default function Sidebar() {
       <h2 className="text-2xl font-bold">TeCuido</h2>
       <nav className="flex flex-col gap-3">
         <Link to="/dashboard" className="hover:underline">Dashboard</Link>
-        <Link to="/medications" className="hover:underline">Medications</Link>
-        <Link to="/appointments" className="hover:underline">Appointments</Link>
-        <Link to="/chatbot" className="hover:underline">Chatbot</Link>
+        <Link to="/dashboard/medications" className="hover:underline">Medications</Link>
+        <Link to="/dashboard/appointments" className="hover:underline">Appointments</Link>
+        <Link to="/dashboard/chatbot" className="hover:underline">Chatbot</Link>
       </nav>
     </div>
   );

--- a/src/pages/Appointments.jsx
+++ b/src/pages/Appointments.jsx
@@ -1,12 +1,7 @@
-import Sidebar from '../components/Sidebar';
-
 export default function Appointments() {
   return (
-    <div className="flex">
-      <Sidebar />
-      <div className="flex-1 p-6">
-        <h1 className="text-2xl font-bold">📅 Appointments</h1>
-      </div>
+    <div>
+      <h1 className="text-2xl font-bold">📅 Appointments</h1>
     </div>
   );
 }

--- a/src/pages/Chatbot.jsx
+++ b/src/pages/Chatbot.jsx
@@ -1,12 +1,7 @@
-import Sidebar from '../components/Sidebar';
-
 export default function Chatbot() {
   return (
-    <div className="flex">
-      <Sidebar />
-      <div className="flex-1 p-6">
-        <h1 className="text-2xl font-bold">🤖 Chatbot</h1>
-      </div>
+    <div>
+      <h1 className="text-2xl font-bold">🤖 Chatbot</h1>
     </div>
   );
 }

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -1,3 +1,4 @@
+import { Outlet } from 'react-router-dom';
 import Sidebar from '../components/Sidebar';
 
 export default function Dashboard() {
@@ -5,7 +6,7 @@ export default function Dashboard() {
     <div className="flex">
       <Sidebar />
       <div className="flex-1 p-6">
-        <h1 className="text-2xl font-bold">📋 Dashboard</h1>
+        <Outlet />
       </div>
     </div>
   );

--- a/src/pages/Landing.jsx
+++ b/src/pages/Landing.jsx
@@ -1,0 +1,61 @@
+import { useEffect, useState } from "react";
+import { auth, signIn, logout } from "../database/firebaseResources";
+import { onAuthStateChanged } from "firebase/auth";
+import "../App.css";
+
+export default function Landing() {
+  const [user, setUser] = useState(null);
+
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(auth, (user) => {
+      setUser(user);
+    });
+
+    return () => unsubscribe();
+  }, []);
+
+  return (
+    <div className="app-container">
+      <div className="card-wrapper">
+        <section className="hero">
+          <h1>
+            Welcome to <span className="highlight">TeCuido</span>
+          </h1>
+          <p className="tagline">Never miss a dose</p>
+          {user ? (
+            <>
+              <h2>Hello, {user.displayName}</h2>
+              <img src={user.photoURL} alt="Profile" className="profile-img" />
+              <button onClick={logout} className="btn">Sign Out</button>
+            </>
+          ) : (
+            <button onClick={signIn} className="btn cta-btn">Get Started</button>
+          )}
+          <p className="description">
+            This is your personal medication reminder app.
+          </p>
+        </section>
+        <section className="features">
+          <h3>How it works</h3>
+          <div className="features-container">
+            <div className="feature-card">
+              <span className="icon">📋</span>
+              <h4>Add Medications</h4>
+              <p>Keep track of your daily prescriptions with ease.</p>
+            </div>
+            <div className="feature-card">
+              <span className="icon">⏰</span>
+              <h4>Timely Reminders</h4>
+              <p>Never miss a dose, get notified right on time.</p>
+            </div>
+            <div className="feature-card">
+              <span className="icon">📈</span>
+              <h4>Stay On Track</h4>
+              <p>Monitor your routine and build consistency.</p>
+            </div>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Medications.jsx
+++ b/src/pages/Medications.jsx
@@ -1,12 +1,7 @@
-import Sidebar from '../components/Sidebar';
-
 export default function Medications() {
   return (
-    <div className="flex">
-      <Sidebar />
-      <div className="flex-1 p-6">
-        <h1 className="text-2xl font-bold">💊 Medications</h1>
-      </div>
+    <div>
+      <h1 className="text-2xl font-bold">💊 Medications</h1>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- create `Landing` page from previous `App` content
- wire router in `App.jsx`
- use `<Outlet>` in `Dashboard` layout
- simplify page components and update sidebar links

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684234dbb3088323ad9c8d6069e59f72