### PR TITLE
Redesign with new Tailwind layout

### DIFF
--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,15 +1,55 @@
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 
-export default function Sidebar() {
+export default function Sidebar({ open, setOpen }) {
+  const location = useLocation();
+  const nav = [
+    {
+      path: '/dashboard/medications',
+      label: 'Medications',
+      icon: (
+        <svg className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" d="M7 7h10M7 11h10M7 15h10M5 3h14a2 2 0 012 2v14a2 2 0 01-2 2H5a2 2 0 01-2-2V5a2 2 0 012-2z" />
+        </svg>
+      ),
+    },
+    {
+      path: '/dashboard/appointments',
+      label: 'Appointments',
+      icon: (
+        <svg className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+          <rect x="3" y="4" width="18" height="18" rx="2" />
+          <path d="M16 2v4M8 2v4M3 10h18" />
+        </svg>
+      ),
+    },
+    {
+      path: '/dashboard/chatbot',
+      label: 'Chatbot',
+      icon: (
+        <svg className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" d="M7 8h10M7 12h6m-6 4h8m5-9a9 9 0 11-18 0 9 9 0 0118 0z" />
+        </svg>
+      ),
+    },
+  ];
+
   return (
-    <div className="h-screen w-64 bg-gray-900 text-white p-6 space-y-6">
-      <h2 className="text-2xl font-bold">TeCuido</h2>
-      <nav className="flex flex-col gap-3">
-        <Link to="/dashboard" className="hover:underline">Dashboard</Link>
-        <Link to="/dashboard/medications" className="hover:underline">Medications</Link>
-        <Link to="/dashboard/appointments" className="hover:underline">Appointments</Link>
-        <Link to="/dashboard/chatbot" className="hover:underline">Chatbot</Link>
-      </nav>
+    <div
+      className={`fixed inset-y-0 left-0 z-50 w-64 transform bg-gray-800 text-gray-100 transition-transform duration-200 md:translate-x-0 md:static md:inset-0 ${open ? 'translate-x-0' : '-translate-x-full'}`}
+    >
+      <div className="mt-16 p-4 space-y-2">
+        {nav.map((item) => (
+          <Link
+            key={item.path}
+            to={item.path}
+            onClick={() => setOpen(false)}
+            className={`flex items-center gap-3 px-3 py-2 rounded hover:bg-gray-700 transition ${location.pathname === item.path ? 'bg-gray-700 text-indigo-400' : ''}`}
+          >
+            {item.icon}
+            <span>{item.label}</span>
+          </Link>
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/components/Topbar.jsx
+++ b/src/components/Topbar.jsx
@@ -1,0 +1,52 @@
+import { useEffect, useState } from 'react';
+import { auth } from '../database/firebaseResources';
+
+export default function Topbar({ onMenuClick }) {
+  const [darkMode, setDarkMode] = useState(false);
+  const user = auth.currentUser;
+
+  useEffect(() => {
+    if (darkMode) {
+      document.documentElement.classList.add('dark');
+    } else {
+      document.documentElement.classList.remove('dark');
+    }
+  }, [darkMode]);
+
+  return (
+    <header className="fixed top-0 inset-x-0 z-40 flex items-center justify-between bg-white dark:bg-gray-800 shadow px-4 py-3 md:ml-64">
+      <div className="flex items-center gap-2">
+        <button
+          onClick={onMenuClick}
+          className="md:hidden p-2 rounded hover:bg-gray-100 dark:hover:bg-gray-700"
+          aria-label="Open sidebar"
+        >
+          <svg className="w-6 h-6" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+        </button>
+        <span className="font-bold text-indigo-600">TeCuido</span>
+      </div>
+      <div className="flex items-center gap-4">
+        <button
+          onClick={() => setDarkMode(!darkMode)}
+          className="p-2 rounded hover:bg-gray-100 dark:hover:bg-gray-700"
+          aria-label="Toggle dark mode"
+        >
+          {darkMode ? (
+            <svg className="w-6 h-6" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M12 3v1m0 16v1m8.66-9H21M3 12h1m15.364 5.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+            </svg>
+          ) : (
+            <svg className="w-6 h-6" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M21 12.79A9 9 0 1111.21 3a7 7 0 009.79 9.79z" />
+            </svg>
+          )}
+        </button>
+        {user && (
+          <img src={user.photoURL} alt="Profile" className="w-8 h-8 rounded-full" />
+        )}
+      </div>
+    </header>
+  );
+}

--- a/src/pages/Appointments.jsx
+++ b/src/pages/Appointments.jsx
@@ -1,7 +1,18 @@
 export default function Appointments() {
+  const appts = ['Dentist - 10/10', 'Checkup - 11/05'];
   return (
-    <div>
-      <h1 className="text-2xl font-bold">📅 Appointments</h1>
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold mb-4">Appointments</h1>
+      <ul className="space-y-2">
+        {appts.map((a) => (
+          <li key={a} className="p-3 bg-white dark:bg-gray-700 rounded shadow">
+            {a}
+          </li>
+        ))}
+      </ul>
+      <button className="mt-4 px-4 py-2 bg-sky-500 text-white rounded hover:bg-sky-600 transition">
+        Add Appointment
+      </button>
     </div>
   );
 }

--- a/src/pages/Chatbot.jsx
+++ b/src/pages/Chatbot.jsx
@@ -1,7 +1,22 @@
+import { useState } from 'react';
+
 export default function Chatbot() {
+  const [messages, setMessages] = useState([
+    { from: 'bot', text: 'Hi! How can I help you?' },
+  ]);
+
   return (
-    <div>
-      <h1 className="text-2xl font-bold">🤖 Chatbot</h1>
+    <div className="flex flex-col h-full max-h-[70vh]">
+      <h1 className="text-2xl font-bold mb-4">Chatbot</h1>
+      <div className="flex-1 space-y-2 overflow-y-auto p-2 bg-white dark:bg-gray-700 rounded">
+        {messages.map((m, idx) => (
+          <div key={idx} className={`p-2 rounded ${m.from === 'bot' ? 'bg-gray-200 dark:bg-gray-600' : 'bg-sky-500 text-white'}`}>{m.text}</div>
+        ))}
+      </div>
+      <form className="mt-2 flex" onSubmit={(e) => { e.preventDefault(); const text = e.target.msg.value; if (text) { setMessages([...messages, { from: 'user', text }]); e.target.reset(); } }}>
+        <input name="msg" className="flex-1 px-3 py-2 rounded-l border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800" />
+        <button className="px-4 py-2 bg-indigo-600 text-white rounded-r hover:bg-indigo-700 transition">Send</button>
+      </form>
     </div>
   );
 }

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -1,51 +1,20 @@
-import { Link, Outlet } from 'react-router-dom';
+import { Outlet } from 'react-router-dom';
 import { useState } from 'react';
+import Sidebar from '../components/Sidebar.jsx';
+import Topbar from '../components/Topbar.jsx';
 
 export default function Dashboard() {
   const [sidebarOpen, setSidebarOpen] = useState(false);
 
-  const toggleSidebar = () => setSidebarOpen(!sidebarOpen);
-
   return (
-    <div className="flex">
-      {/* Mobile top bar */}
-      <div className="min-h-screen md:flex">
-        <div className="md:hidden flex items-center bg-gray-900 text-white p-4">
-          <button
-            onClick={toggleSidebar}
-            aria-label="Toggle navigation"
-            className="mr-2"
-          >
-            =
-          </button>
-          <span className="text-lg font-bold">TeCuido</span>
-        </div>
+    <div className="min-h-screen flex bg-gray-50 dark:bg-gray-900">
+      <Sidebar open={sidebarOpen} setOpen={setSidebarOpen} />
+      <div className="flex-1 flex flex-col">
+        <Topbar onMenuClick={() => setSidebarOpen(true)} />
+        <main className="flex-1 mt-16 p-4 overflow-y-auto">
+          <Outlet />
+        </main>
       </div>
-
-      </div>
-
-      {/* Sidebar */}
-      <aside
-        className={`bg-gray-900 text-white w-64 space-y-6 p-6 md:sticky md:top-0 md:h-screen ${
-          sidebarOpen ? 'block' : 'hidden'
-        } md:block`}
-      >
-        <nav className="flex flex-col gap-3">
-          <Link to="/medications" className="hover:underline">
-            Medications
-          </Link>
-          <Link to="/appointments" className="hover:underline">
-            Appointments
-          </Link>
-          <Link to="/chatbot" className="hover:underline">
-            Chatbot
-          </Link>
-        </nav>
-      </aside>
-
-      <main className="flex-1 p-6">
-        <Outlet />
-      </main>
     </div>
   );
 }

--- a/src/pages/Landing.jsx
+++ b/src/pages/Landing.jsx
@@ -1,61 +1,43 @@
-import { useEffect, useState } from "react";
-import { auth, signIn, logout } from "../database/firebaseResources";
-import { onAuthStateChanged } from "firebase/auth";
-import "../App.css";
+import { useEffect, useState } from 'react';
+import { auth, signIn, logout } from '../database/firebaseResources';
+import { onAuthStateChanged } from 'firebase/auth';
+import { Link } from 'react-router-dom';
 
 export default function Landing() {
   const [user, setUser] = useState(null);
 
   useEffect(() => {
-    const unsubscribe = onAuthStateChanged(auth, (user) => {
-      setUser(user);
-    });
-
-    return () => unsubscribe();
+    const unsub = onAuthStateChanged(auth, (u) => setUser(u));
+    return () => unsub();
   }, []);
 
   return (
-    <div className="app-container">
-      <div className="card-wrapper">
-        <section className="hero">
-          <h1>
-            Welcome to <span className="highlight">TeCuido</span>
-          </h1>
-          <p className="tagline">Never miss a dose</p>
-          {user ? (
-            <>
-              <h2>Hello, {user.displayName}</h2>
-              <img src={user.photoURL} alt="Profile" className="profile-img" />
-              <button onClick={logout} className="btn">Sign Out</button>
-            </>
-          ) : (
-            <button onClick={signIn} className="btn cta-btn">Get Started</button>
-          )}
-          <p className="description">
-            This is your personal medication reminder app.
-          </p>
-        </section>
-        <section className="features">
-          <h3>How it works</h3>
-          <div className="features-container">
-            <div className="feature-card">
-              <span className="icon">📋</span>
-              <h4>Add Medications</h4>
-              <p>Keep track of your daily prescriptions with ease.</p>
-            </div>
-            <div className="feature-card">
-              <span className="icon">⏰</span>
-              <h4>Timely Reminders</h4>
-              <p>Never miss a dose, get notified right on time.</p>
-            </div>
-            <div className="feature-card">
-              <span className="icon">📈</span>
-              <h4>Stay On Track</h4>
-              <p>Monitor your routine and build consistency.</p>
-            </div>
-          </div>
-        </section>
-      </div>
+    <div className="min-h-screen flex flex-col justify-center items-center bg-gray-50 dark:bg-gray-900 p-4 text-center">
+      <h1 className="text-4xl md:text-5xl font-extrabold mb-4">
+        Welcome to <span className="text-sky-500">TeCuido</span>
+      </h1>
+      <p className="text-gray-600 dark:text-gray-300 mb-8 max-w-xl">
+        Never miss a dose or appointment. Keep your health on track with reminders and chat support.
+      </p>
+      {user ? (
+        <>
+          <Link to="/dashboard" className="px-6 py-3 rounded bg-indigo-600 text-white hover:bg-indigo-700 transition">
+            Go to Dashboard
+          </Link>
+          <button onClick={logout} className="mt-4 text-sm text-sky-500 hover:underline">
+            Sign Out
+          </button>
+        </>
+      ) : (
+        <button onClick={signIn} className="px-6 py-3 rounded bg-sky-500 text-white hover:bg-sky-600 transition">
+          Get Started
+        </button>
+      )}
+      <ul className="mt-12 space-y-2 text-left text-gray-600 dark:text-gray-300">
+        <li>📋 Add medications with schedules</li>
+        <li>⏰ Receive timely reminders</li>
+        <li>📈 Track your progress over time</li>
+      </ul>
     </div>
   );
 }

--- a/src/pages/Medications.jsx
+++ b/src/pages/Medications.jsx
@@ -1,7 +1,18 @@
 export default function Medications() {
+  const meds = ['Ibuprofen', 'Aspirin'];
   return (
-    <div>
-      <h1 className="text-2xl font-bold">💊 Medications</h1>
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold mb-4">Medications</h1>
+      <ul className="space-y-2">
+        {meds.map((m) => (
+          <li key={m} className="p-3 bg-white dark:bg-gray-700 rounded shadow">
+            {m}
+          </li>
+        ))}
+      </ul>
+      <button className="mt-4 px-4 py-2 bg-sky-500 text-white rounded hover:bg-sky-600 transition">
+        Add Medication
+      </button>
     </div>
   );
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,10 @@
+/* eslint-disable */
+/* eslint-env node */
+module.exports = {
+  darkMode: 'class',
+  content: ['./index.html', './src/**/*.{js,jsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}


### PR DESCRIPTION
## Summary
- add Tailwind config for class-based dark mode
- create Topbar with hamburger, dark mode toggle and profile picture
- redesign Sidebar with icons and active link highlighting
- update landing page hero and add dashboard layout
- flesh out medications, appointments and chatbot pages

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6842384f10b88323bcc31145f8b2a559