### PR TITLE
Add modern theme and animations

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "@tailwindcss/vite": "^4.1.8",
     "firebase": "^11.8.1",
     "firebaseui": "^6.1.0",
+    "framer-motion": "^11.0.0",
+    "lucide-react": "^0.321.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-firebaseui": "^6.0.0",

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,55 +1,69 @@
 import { Link, useLocation } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import { motion as Motion } from 'framer-motion';
+import { Pill, CalendarCheck, Bot } from 'lucide-react';
 
 export default function Sidebar({ open, setOpen }) {
   const location = useLocation();
+  const [isDesktop, setIsDesktop] = useState(false);
+
+  useEffect(() => {
+    const check = () => setIsDesktop(window.innerWidth >= 768);
+    check();
+    window.addEventListener('resize', check);
+    return () => window.removeEventListener('resize', check);
+  }, []);
+
   const nav = [
     {
       path: '/dashboard/medications',
       label: 'Medications',
-      icon: (
-        <svg className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-          <path strokeLinecap="round" strokeLinejoin="round" d="M7 7h10M7 11h10M7 15h10M5 3h14a2 2 0 012 2v14a2 2 0 01-2 2H5a2 2 0 01-2-2V5a2 2 0 012-2z" />
-        </svg>
-      ),
+      icon: Pill,
     },
     {
       path: '/dashboard/appointments',
       label: 'Appointments',
-      icon: (
-        <svg className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-          <rect x="3" y="4" width="18" height="18" rx="2" />
-          <path d="M16 2v4M8 2v4M3 10h18" />
-        </svg>
-      ),
+      icon: CalendarCheck,
     },
     {
       path: '/dashboard/chatbot',
       label: 'Chatbot',
-      icon: (
-        <svg className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-          <path strokeLinecap="round" strokeLinejoin="round" d="M7 8h10M7 12h6m-6 4h8m5-9a9 9 0 11-18 0 9 9 0 0118 0z" />
-        </svg>
-      ),
+      icon: Bot,
     },
   ];
 
+  const container = {
+    show: { transition: { staggerChildren: 0.1 } },
+  };
+
+  const item = {
+    hidden: { opacity: 0, x: -20 },
+    show: { opacity: 1, x: 0 },
+  };
+
   return (
-    <div
-      className={`fixed inset-y-0 left-0 z-50 w-64 transform bg-gray-800 text-gray-100 transition-transform duration-200 md:translate-x-0 md:static md:inset-0 ${open ? 'translate-x-0' : '-translate-x-full'}`}
+    <Motion.aside
+      initial={false}
+      animate={isDesktop || open ? { x: 0 } : { x: -260 }}
+      transition={{ type: 'tween' }}
+      className="fixed inset-y-0 left-0 z-50 w-64 bg-[#0d0d0d] text-[#f5f5dc] md:static md:translate-x-0"
     >
-      <div className="mt-16 p-4 space-y-2">
-        {nav.map((item) => (
-          <Link
-            key={item.path}
-            to={item.path}
-            onClick={() => setOpen(false)}
-            className={`flex items-center gap-3 px-3 py-2 rounded hover:bg-gray-700 transition ${location.pathname === item.path ? 'bg-gray-700 text-indigo-400' : ''}`}
-          >
-            {item.icon}
-            <span>{item.label}</span>
-          </Link>
+      <Motion.div className="mt-16 p-4 space-y-2" variants={container} initial="hidden" animate="show">
+        {nav.map((itemNav) => (
+          <Motion.div key={itemNav.path} variants={item}>
+            <Link
+              to={itemNav.path}
+              onClick={() => setOpen(false)}
+              className={`flex items-center gap-3 px-3 py-2 rounded transition-transform hover:scale-105 hover:text-sky-500 ${
+                location.pathname === itemNav.path ? 'text-sky-500 font-semibold border-r-4 border-sky-500' : ''
+              }`}
+            >
+              <itemNav.icon className="w-5 h-5" />
+              <span>{itemNav.label}</span>
+            </Link>
+          </Motion.div>
         ))}
-      </div>
-    </div>
+      </Motion.div>
+    </Motion.aside>
   );
 }

--- a/src/components/Topbar.jsx
+++ b/src/components/Topbar.jsx
@@ -14,7 +14,7 @@ export default function Topbar({ onMenuClick }) {
   }, [darkMode]);
 
   return (
-    <header className="fixed top-0 inset-x-0 z-40 flex items-center justify-between bg-white dark:bg-gray-800 shadow px-4 py-3 md:ml-64">
+    <header className="fixed top-0 inset-x-0 z-40 flex items-center justify-between bg-[#0d0d0d] text-[#f5f5dc] shadow px-4 py-3 md:ml-64 transition">
       <div className="flex items-center gap-2">
         <button
           onClick={onMenuClick}

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -7,10 +7,10 @@ export default function Dashboard() {
   const [sidebarOpen, setSidebarOpen] = useState(false);
 
   return (
-    <div className="min-h-screen flex bg-gray-50 dark:bg-gray-900">
+    <div className="min-h-screen flex bg-[#0d0d0d] text-[#f5f5dc]">
       <Sidebar open={sidebarOpen} setOpen={setSidebarOpen} />
       <div className="flex-1 flex flex-col">
-        <Topbar onMenuClick={() => setSidebarOpen(true)} />
+        <Topbar onMenuClick={() => setSidebarOpen(!sidebarOpen)} />
         <main className="flex-1 mt-16 p-4 overflow-y-auto">
           <Outlet />
         </main>

--- a/src/pages/Landing.jsx
+++ b/src/pages/Landing.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { auth, signIn, logout } from '../database/firebaseResources';
 import { onAuthStateChanged } from 'firebase/auth';
 import { Link } from 'react-router-dom';
+import { motion as Motion } from 'framer-motion';
 
 export default function Landing() {
   const [user, setUser] = useState(null);
@@ -13,13 +14,30 @@ export default function Landing() {
 
   return (
     <div className="min-h-screen flex items-center justify-center bg-[#0d0d0d] px-4">
-      <div className="max-w-lg w-full mx-auto my-20 text-center text-[#f5f5dc] font-sans">
-        <h1 className="font-bold text-4xl md:text-5xl mb-6">Welcome to TeCuido</h1>
+      <Motion.div
+        initial={{ opacity: 0, y: -30 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.6 }}
+        className="max-w-lg w-full mx-auto my-20 text-center text-[#f5f5dc] font-sans"
+      >
+        <Motion.h1
+          initial={{ opacity: 0, y: -20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.1 }}
+          className="font-bold text-4xl md:text-5xl mb-6"
+        >
+          Welcome to TeCuido
+        </Motion.h1>
         <p className="mb-8 text-[#f5f5dc]/80">
           Never miss a dose or appointment. Keep your health on track with reminders and chat support.
         </p>
         {user ? (
-          <div className="flex flex-col items-center gap-4">
+          <Motion.div
+            initial={{ opacity: 0, y: -10 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.2 }}
+            className="flex flex-col items-center gap-4"
+          >
             <Link
               to="/dashboard"
               className="px-6 py-3 rounded bg-[#f5f5dc] text-black hover:bg-[#e5e5c4] transition"
@@ -32,21 +50,32 @@ export default function Landing() {
             >
               Sign Out
             </button>
-          </div>
+          </Motion.div>
         ) : (
-          <button
+          <Motion.button
+            initial={{ opacity: 0, y: -10 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.2 }}
             onClick={signIn}
             className="px-6 py-3 rounded bg-[#f5f5dc] text-black hover:bg-[#e5e5c4] transition"
           >
             Get Started
-          </button>
+          </Motion.button>
         )}
-        <ul className="mt-10 flex flex-col items-start gap-4 text-sm font-light mx-auto max-w-fit">
-          <li>📋 Add medications with schedules</li>
-          <li>⏰ Receive timely reminders</li>
-          <li>📈 Track your progress over time</li>
-        </ul>
-      </div>
+        <Motion.ul
+          initial="hidden"
+          whileInView="visible"
+          viewport={{ once: true }}
+          variants={{ hidden: {}, visible: { transition: { staggerChildren: 0.1 } } }}
+          className="mt-10 flex flex-col items-start gap-4 text-sm font-light mx-auto max-w-fit"
+        >
+          {['📋 Add medications with schedules', '⏰ Receive timely reminders', '📈 Track your progress over time'].map((t) => (
+            <Motion.li key={t} variants={{ hidden: { opacity: 0, y: 10 }, visible: { opacity: 1, y: 0 } }}>
+              {t}
+            </Motion.li>
+          ))}
+        </Motion.ul>
+      </Motion.div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- update dashboard layout colors
- animate slide-in sidebar with staggered items
- style topbar with dark theme
- add framer motion animations for landing page
- include lucide-react icons in sidebar
- add framer-motion and lucide-react dependencies

## Testing
- `npm run lint`
- `npm run build` *(fails: Rollup failed to resolve import "framer-motion")*

------
https://chatgpt.com/codex/tasks/task_e_68423c903e188323b6e9cce515300e0d