### PR TITLE
Improve UI persistence

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -12,8 +12,8 @@ service cloud.firestore {
     // Make sure to write security rules for your app before that time, or else
     // all client requests to your Firestore database will be denied until you Update
     // your rules
-    match /{document=**} {
-      allow read, write: if request.time < timestamp.date(2025, 6, 27);
+    match /users/{userId}/{document=**} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
     }
   }
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,13 +4,14 @@ import Dashboard from './pages/Dashboard.jsx';
 import Medications from './pages/Medications.jsx';
 import Appointments from './pages/Appointments.jsx';
 import Chatbot from './pages/Chatbot.jsx';
+import RequireAuth from './components/RequireAuth.jsx';
 
 export default function App() {
   return (
     <BrowserRouter>
       <Routes>
         <Route path="/" element={<Landing />} />
-        <Route path="/dashboard" element={<Dashboard />}>
+        <Route path="/dashboard" element={<RequireAuth><Dashboard /></RequireAuth>}>
           <Route path="medications" element={<Medications />} />
           <Route path="appointments" element={<Appointments />} />
           <Route path="chatbot" element={<Chatbot />} />

--- a/src/components/RequireAuth.jsx
+++ b/src/components/RequireAuth.jsx
@@ -1,0 +1,22 @@
+import { useEffect, useState } from 'react';
+import { Navigate } from 'react-router-dom';
+import { auth } from '../database/firebaseResources';
+
+export default function RequireAuth({ children }) {
+  const [user, setUser] = useState(() => auth.currentUser);
+  const [loading, setLoading] = useState(!auth.currentUser);
+
+  useEffect(() => {
+    const unsub = auth.onAuthStateChanged((u) => {
+      setUser(u);
+      setLoading(false);
+    });
+    return () => unsub();
+  }, []);
+
+  if (loading) {
+    return null;
+  }
+
+  return user ? children : <Navigate to="/" replace />;
+}

--- a/src/components/Topbar.jsx
+++ b/src/components/Topbar.jsx
@@ -2,7 +2,10 @@ import { useEffect, useState } from 'react';
 import { auth } from '../database/firebaseResources';
 
 export default function Topbar({ onMenuClick }) {
-  const [darkMode, setDarkMode] = useState(false);
+  const [darkMode, setDarkMode] = useState(() => {
+    const stored = localStorage.getItem('darkMode');
+    return stored ? stored === 'true' : false;
+  });
   const user = auth.currentUser;
 
   useEffect(() => {
@@ -11,6 +14,7 @@ export default function Topbar({ onMenuClick }) {
     } else {
       document.documentElement.classList.remove('dark');
     }
+    localStorage.setItem('darkMode', darkMode);
   }, [darkMode]);
 
   return (

--- a/src/pages/Appointments.jsx
+++ b/src/pages/Appointments.jsx
@@ -1,18 +1,47 @@
+import { useEffect, useState } from 'react';
+
 export default function Appointments() {
-  const appts = ['Dentist - 10/10', 'Checkup - 11/05'];
+  const [appts, setAppts] = useState(() => {
+    const stored = localStorage.getItem('appointments');
+    return stored ? JSON.parse(stored) : ['Dentist - 10/10', 'Checkup - 11/05'];
+  });
+
+  useEffect(() => {
+    localStorage.setItem('appointments', JSON.stringify(appts));
+  }, [appts]);
+
+  const addAppt = (e) => {
+    e.preventDefault();
+    const text = e.target.appt.value.trim();
+    if (text) {
+      setAppts([...appts, text]);
+      e.target.reset();
+    }
+  };
+
+  const removeAppt = (idx) => {
+    setAppts(appts.filter((_, i) => i !== idx));
+  };
+
   return (
     <div className="space-y-4">
       <h1 className="text-2xl font-bold mb-4">Appointments</h1>
       <ul className="space-y-2">
-        {appts.map((a) => (
-          <li key={a} className="p-3 bg-white dark:bg-gray-700 rounded shadow">
+        {appts.map((a, idx) => (
+          <li key={idx} className="p-3 bg-white dark:bg-gray-700 rounded shadow flex justify-between items-center">
             {a}
+            <button onClick={() => removeAppt(idx)} className="text-sm text-red-500">Delete</button>
           </li>
         ))}
       </ul>
-      <button className="mt-4 px-4 py-2 bg-sky-500 text-white rounded hover:bg-sky-600 transition">
-        Add Appointment
-      </button>
+      <form onSubmit={addAppt} className="flex gap-2">
+        <input
+          name="appt"
+          className="flex-1 px-3 py-2 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800"
+          placeholder="New appointment"
+        />
+        <button className="px-4 py-2 bg-sky-500 text-white rounded hover:bg-sky-600 transition">Add</button>
+      </form>
     </div>
   );
 }

--- a/src/pages/Chatbot.jsx
+++ b/src/pages/Chatbot.jsx
@@ -5,6 +5,13 @@ export default function Chatbot() {
     { from: 'bot', text: 'Hi! How can I help you?' },
   ]);
 
+  const sendMessage = (text) => {
+    setMessages((prev) => [...prev, { from: 'user', text }]);
+    setTimeout(() => {
+      setMessages((prev) => [...prev, { from: 'bot', text: `You said: ${text}` }]);
+    }, 500);
+  };
+
   return (
     <div className="flex flex-col h-full max-h-[70vh]">
       <h1 className="text-2xl font-bold mb-4">Chatbot</h1>
@@ -13,7 +20,17 @@ export default function Chatbot() {
           <div key={idx} className={`p-2 rounded ${m.from === 'bot' ? 'bg-gray-200 dark:bg-gray-600' : 'bg-sky-500 text-white'}`}>{m.text}</div>
         ))}
       </div>
-      <form className="mt-2 flex" onSubmit={(e) => { e.preventDefault(); const text = e.target.msg.value; if (text) { setMessages([...messages, { from: 'user', text }]); e.target.reset(); } }}>
+      <form
+        className="mt-2 flex"
+        onSubmit={(e) => {
+          e.preventDefault();
+          const text = e.target.msg.value.trim();
+          if (text) {
+            sendMessage(text);
+            e.target.reset();
+          }
+        }}
+      >
         <input name="msg" className="flex-1 px-3 py-2 rounded-l border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800" />
         <button className="px-4 py-2 bg-indigo-600 text-white rounded-r hover:bg-indigo-700 transition">Send</button>
       </form>

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,3 +1,0 @@
-export default function Home() {
-    return <div className="p-8 text-xl">🏠 Welcome to TeCuido!</div>;
-  }

--- a/src/pages/Medications.jsx
+++ b/src/pages/Medications.jsx
@@ -1,18 +1,47 @@
+import { useEffect, useState } from 'react';
+
 export default function Medications() {
-  const meds = ['Ibuprofen', 'Aspirin'];
+  const [meds, setMeds] = useState(() => {
+    const stored = localStorage.getItem('medications');
+    return stored ? JSON.parse(stored) : ['Ibuprofen', 'Aspirin'];
+  });
+
+  useEffect(() => {
+    localStorage.setItem('medications', JSON.stringify(meds));
+  }, [meds]);
+
+  const addMed = (e) => {
+    e.preventDefault();
+    const text = e.target.med.value.trim();
+    if (text) {
+      setMeds([...meds, text]);
+      e.target.reset();
+    }
+  };
+
+  const removeMed = (idx) => {
+    setMeds(meds.filter((_, i) => i !== idx));
+  };
+
   return (
     <div className="space-y-4">
       <h1 className="text-2xl font-bold mb-4">Medications</h1>
       <ul className="space-y-2">
-        {meds.map((m) => (
-          <li key={m} className="p-3 bg-white dark:bg-gray-700 rounded shadow">
+        {meds.map((m, idx) => (
+          <li key={idx} className="p-3 bg-white dark:bg-gray-700 rounded shadow flex justify-between items-center">
             {m}
+            <button onClick={() => removeMed(idx)} className="text-sm text-red-500">Delete</button>
           </li>
         ))}
       </ul>
-      <button className="mt-4 px-4 py-2 bg-sky-500 text-white rounded hover:bg-sky-600 transition">
-        Add Medication
-      </button>
+      <form onSubmit={addMed} className="flex gap-2">
+        <input
+          name="med"
+          className="flex-1 px-3 py-2 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800"
+          placeholder="New medication"
+        />
+        <button className="px-4 py-2 bg-sky-500 text-white rounded hover:bg-sky-600 transition">Add</button>
+      </form>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- persist dark mode setting across reloads
- persist medications and appointments using local storage
- give the chatbot simple automatic replies
- protect dashboard routes behind authentication
- tighten Firestore security rules
- remove unused `Home.jsx`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68423fed405c832389886a31c46935a3